### PR TITLE
悬浮球贴边修复

### DIFF
--- a/FloatWindowPermission/app/src/main/java/com/android/permission/AVCallFloatView.java
+++ b/FloatWindowPermission/app/src/main/java/com/android/permission/AVCallFloatView.java
@@ -144,7 +144,7 @@ public class AVCallFloatView extends FrameLayout {
             xDistance = dp_25 - mParams.x;
         }
         //3
-        else if (middleX >= screenWidth - getWidth() / 2 - dp2px(25)) {
+        else if (middleX >= screenWidth - getWidth() / 2 - dp_25) {
             xDistance = screenWidth - mParams.x - getWidth() - dp_25;
         }
         //4
@@ -195,6 +195,11 @@ public class AVCallFloatView extends FrameLayout {
         @Override
         public void run() {
             if (System.currentTimeMillis() >= currentStartTime + animTime) {
+                if (mParams.x != (startX + xDistance) || mParams.y != (startY + yDistance)) {
+                    mParams.x = startX + xDistance;
+                    mParams.y = startY + yDistance;
+                    windowManager.updateViewLayout(AVCallFloatView.this, mParams);
+                }
                 isAnchoring = false;
                 return;
             }


### PR DESCRIPTION
一种情况是如果移动距离较小，导致 animTime 较小，在 run 方法里可能第一次就直接返回。
另一种是最后一次执行，发现时间到了，但是前一次位置并未完全移到贴边的位置。
所以在这里确保最后的位置是正确的。